### PR TITLE
resolvedtiles: combine_resolvedtiles function

### DIFF
--- a/renderapi/resolvedtiles.py
+++ b/renderapi/resolvedtiles.py
@@ -53,6 +53,32 @@ class ResolvedTiles:
     """  # noqa: E501
 
 
+def combine_resolvedtiles(rts_l):
+    """combine multiple ResolvedTiles objects into a single ResolvedTiles
+
+    Like render, this has an implicit expectation that transformIds and tileIds
+      are unique among all input objects
+
+    Parameters
+    ----------
+    rts_l : list[renderapi.resolvedtiles.ResolvedTiles]
+        list of ResolvedTiles objects to combine
+
+    Returns
+    -------
+    rts : renderapi.resolvedtiles.ResolvedTiles
+        combined ResolvedTiles object
+    """
+    tforms = list({tform.transformId: tform for l in (
+        rts.transforms for rts in rts_l)
+                   for tform in l}.values())
+    tspecs = list({ts.tileId: ts for l in (
+        rts.tilespecs for rts in rts_l)
+                   for ts in l}.values())
+
+    return ResolvedTiles(transformList=tforms, tilespecs=tspecs)
+
+
 @renderaccess
 def put_tilespecs(stack, resolved_tiles=None, deriveData=True,
                   tilespecs=None, shared_transforms=None,

--- a/test/test_resolvedtiles.py
+++ b/test/test_resolvedtiles.py
@@ -24,6 +24,15 @@ def resolvedtiles_object(referenced_tilespecs_and_transforms):
     return resolved_tiles
 
 
+@pytest.fixture(scope="module")
+def resolvedtiles_objects(resolvedtiles_object):
+    # one resolvedtiles object per tile in the resolvedtiles_object
+    rts_l = [renderapi.resolvedtiles.ResolvedTiles(
+        tilespecs=[ts], transformList=resolvedtiles_object.transforms)
+             for ts in resolvedtiles_object.tilespecs]
+    return rts_l
+
+
 def test_resolvedtiles_from_dict(resolvedtiles_object,
                                  referenced_tilespecs_and_transforms):
     tilespecs, transforms = referenced_tilespecs_and_transforms
@@ -31,3 +40,9 @@ def test_resolvedtiles_from_dict(resolvedtiles_object,
     resolved_tiles = renderapi.resolvedtiles.ResolvedTiles(json=d)
     assert(len(tilespecs) == len(resolved_tiles.tilespecs))
     assert(len(transforms) == len(resolved_tiles.transforms))
+
+
+def test_combine_resolvedtiles(resolvedtiles_object, resolvedtiles_objects):
+    assert(resolvedtiles_object.to_dict() ==
+           renderapi.resolvedtiles.combine_resolvedtiles(
+               resolvedtiles_objects).to_dict())


### PR DESCRIPTION
function to create one `renderapi.resolvedtiles.ResolvedTiles` object from multiple.