### PR TITLE
pointmatch: add functions for fast and deep copy

### DIFF
--- a/renderapi/pointmatch.py
+++ b/renderapi/pointmatch.py
@@ -11,6 +11,51 @@ logger = logging.getLogger(__name__)
 logger.addHandler(NullHandler())
 
 
+def copy_match_explicit(match):
+    """create independent match dictionary equivalent to the input match
+      significantly faster than e.g. copy.deepcopy or json serialization
+
+    Parameters
+    ----------
+    match : dict
+      match dictionary
+
+    Returns
+    -------
+    new_match : dict
+      match dictionary equivalent to input match
+
+    """
+    # explicitly copy match dictionary since it contains lists
+    new_matchd = {
+        "p": [i[:] for i in match["matches"]["p"]],
+        "q": [i[:] for i in match["matches"]["q"]],
+        "w": match["matches"]["w"][:]
+    }
+
+    new_match = {k: (match[k] if k != "matches" else new_matchd)
+                 for k in match.keys()}
+    return new_match
+
+
+def copy_matches_explicit(matches):
+    """create independent match dictionaries equivalent to the input matches
+      significantly faster than e.g. copy.deepcopy or json serialization
+
+    Parameters
+    ----------
+    matches :  list[dict]
+      list of match dictionaries to copy
+
+    Returns
+    -------
+    new_matches : list[dict]
+      list of match dictionaries equivalent to input matches
+
+    """
+    return [copy_match_explicit(match) for match in matches]
+
+
 @renderaccess
 def get_matchcollection_owners(host=None, port=None,
                                session=requests.session(),

--- a/test/test_pointmatch.py
+++ b/test/test_pointmatch.py
@@ -1,6 +1,9 @@
 import copy
-import renderapi
+
 import pytest
+import six
+
+import renderapi
 
 
 @pytest.fixture(scope="module")
@@ -87,7 +90,7 @@ def copymatch_and_compare(input_match, tuple_subscript_to_change,
 
 def test_copy_match(match):
     # test for top level keys
-    for k in (match.keys() - {"matches"}):
+    for k in (six.viewkeys(match) - {"matches"}):
         assert not copymatch_and_compare(match, (k,))
     # test for nested values in matches
     for subtup in (("matches", "p", 0, 0),

--- a/test/test_pointmatch.py
+++ b/test/test_pointmatch.py
@@ -1,0 +1,101 @@
+import copy
+import renderapi
+import pytest
+
+
+@pytest.fixture(scope="module")
+def matches():
+    return [{
+        "pGroupId": "0",
+        "pId": "0-1",
+        "qGroupId": "1",
+        "qId": "1-1",
+        "matches": {
+            "p": [[0, 0],
+                  [100, 100],
+                  [0, 100],
+                  [100, 0]],
+            "q": [[0, 0],
+                  [100, 100],
+                  [0, 100],
+                  [100, 0]],
+            "w": [1, 1, 1, 1]},
+        "matchCount": 4
+        },
+      {
+        "pGroupId": "0",
+        "pId": "0-1",
+        "qGroupId": "2",
+        "qId": "2-1",
+        "matches": {
+          "p": [
+            [0, 0],
+            [100, 100],
+            [0, 100],
+            [100, 0]
+          ],
+          "q": [
+            [0, 0],
+            [100, 100],
+            [0, 100],
+            [100, 0]
+          ],
+          "w": [1, 1, 1, 1],
+        },
+        "matchCount": 4
+      },
+      {
+        "pGroupId": "0",
+        "pId": "0-1",
+        "qGroupId": "0",
+        "qId": "0-2",
+        "matches": {
+          "p": [
+            [100, 100],
+            [100, 0]
+          ],
+          "q": [
+            [0, 100],
+            [0, 0]
+          ],
+          "w": [1, 1],
+        },
+        "matchCount": 2
+      }
+    ]
+
+
+@pytest.fixture(scope="module")
+def match(matches):
+    return matches[1]
+
+
+def set_tuple_subscript(obj, tuple_subscript, value):
+    o = obj
+    for s in tuple_subscript[:-1]:
+        o = o.__getitem__(s)
+    return o.__setitem__(tuple_subscript[-1], value)
+
+
+def copymatch_and_compare(input_match, tuple_subscript_to_change,
+                          target_value=None):
+    orig_match = copy.deepcopy(input_match)
+    copied_match = renderapi.pointmatch.copy_match_explicit(orig_match)
+    set_tuple_subscript(orig_match, tuple_subscript_to_change, target_value)
+    return orig_match == copied_match
+
+
+def test_copy_match(match):
+    # test for top level keys
+    for k in (match.keys() - {"matches"}):
+        assert not copymatch_and_compare(match, (k,))
+    # test for nested values in matches
+    for subtup in (("matches", "p", 0, 0),
+                   ("matches", "q", 0, 0),
+                   ("matches", "w", 0)):
+        assert not copymatch_and_compare(match, subtup)
+
+
+def test_copy_matches(matches):
+    assert all([i == j for i, j in zip(
+        matches, renderapi.pointmatch.copy_matches_explicit(matches))])


### PR DESCRIPTION
This adds a function to "copy" pointmatch dictionaries such that changes to the match arrays of the original do not affect the copy.

As background for why this is useful, BigFetA has use cases where it transforms pointmatches in-place.  This becomes a problem when doing multiple-step in-memory alignment or trying to interrogate residuals.  To be on the safe side I've been copying the matches before each step, which is very expensive on large alignments.

The test I added uses the same match objects (via copy/paste) as the integration test, but I am surprised to see that the format of the dictionaries doesn't match what I was seeing in real pointmatch collections, e.g.

`"p": [[1, 2, 3], [1, 2, 3]]`  (pointmatch collection)
vs
`"p": [[1, 1], [2, 2], [3, 3]]` (test fixture)

This actually doesn't affect the way I have the copy implemented, but I'm not sure if this is a long-standing typo or something that changed without us noticing.