### PR TITLE
pass `resolutionUnit` parameter

### DIFF
--- a/renderapi/client/client_calls.py
+++ b/renderapi/client/client_calls.py
@@ -346,10 +346,11 @@ def renderSectionClient(stack, rootDirectory, zs, scale=None,
                         maxIntensity=None, minIntensity=None, bounds=None,
                         format=None, channel=None, customOutputFolder=None,
                         customSubFolder=None, padFileNamesWithZeros=None,
-                        doFilter=None, fillWithNoise=None, imageType=None,
-                        subprocess_mode=None, host=None, port=None, owner=None,
-                        project=None, client_script=None, memGB=None,
-                        render=None, **kwargs):
+                        resolutionUnit=None, doFilter=None, fillWithNoise=None,
+                        imageType=None, subprocess_mode=None, host=None,
+                        port=None, owner=None, project=None,
+                        client_script=None, memGB=None, render=None,
+                        **kwargs):
     """run RenderSectionClient.java
 
     Parameters
@@ -379,6 +380,9 @@ def renderSectionClient(stack, rootDirectory, zs, scale=None,
         folder to save all images in under outputFolder (overrides default of none)
     padFileNamesWithZeros: bool
         whether to pad file names with zeros to make sortable
+    resolutionUnit: str
+        if format is tiff and unit is specified (e.g. as 'nm'), include resolution data 
+        in rendered tiff headers.
     imageType: int
         8,16,24 to specify what kind of image type to save
     doFilter : str
@@ -418,9 +422,11 @@ def renderSectionClient(stack, rootDirectory, zs, scale=None,
              get_param(customOutputFolder, '--customOutputFolder') +
              get_param(imageType, '--imageType') +
              get_param(channel, '--channels') +
-             get_param(customSubFolder, '--customSubFolder') +
+             get_param(customSubFolder, '--customSubFolder') +             
              get_param(padFileNamesWithZeros, '--padFileNamesWithZeros') +
+             get_param(resolutionUnit, '--resolutionUnit') +
              bound_param + zs)
+    
     call_run_ws_client('org.janelia.render.client.RenderSectionClient',
                        memGB=memGB, client_script=client_script,
                        subprocess_mode=subprocess_mode, add_args=argvs,


### PR DESCRIPTION
makes the `resolutionUnit` parameter (https://github.com/saalfeldlab/render/commit/0448e3d7e8229b4837988a577411109c4e6b0b92) available.