### PR TITLE
Update tilepair client to match asap:develop

### DIFF
--- a/renderapi/client/client_calls.py
+++ b/renderapi/client/client_calls.py
@@ -243,8 +243,7 @@ def tilePairClient(stack, minz, maxz, outjson=None, delete_json=False,
                        '--excludeSameSectionNeighbors') +
              get_param(excludePairsInMatchCollection,
                        '--excludePairsInMatchCollection') +
-             get_param(useRowColPositions,
-                       '--useRowColPositions') +
+             (['--useRowColPositions'] if useRowColPositions else []) +
              get_param(existingMatchOwner,
                        '--existingMatchOwner') +
              get_param(minExistingMatchCount,


### PR DESCRIPTION
Make client call compatible with the way Render handles the `useRowColPositions` parameter. ref: https://github.com/AllenInstitute/asap-modules/pull/252